### PR TITLE
Add scroll area to editor window

### DIFF
--- a/src/editor_window.rs
+++ b/src/editor_window.rs
@@ -14,15 +14,17 @@ pub(crate) fn yoleck_editor_window(
     } else {
         return;
     };
-    egui::Window::new("Level Editor").vscroll(true).show(borrowed_egui.get_mut(), |ui| {
-        world.resource_scope(
-            |world, mut yoleck_editor_sections: Mut<YoleckEditorSections>| {
-                for section in yoleck_editor_sections.0.iter_mut() {
-                    section.0.invoke(world, ui);
-                }
-            },
-        );
-    });
+    egui::Window::new("Level Editor")
+        .vscroll(true)
+        .show(borrowed_egui.get_mut(), |ui| {
+            world.resource_scope(
+                |world, mut yoleck_editor_sections: Mut<YoleckEditorSections>| {
+                    for section in yoleck_editor_sections.0.iter_mut() {
+                        section.0.invoke(world, ui);
+                    }
+                },
+            );
+        });
     if let Ok(mut egui_context) = egui_query.get_single_mut(world) {
         *egui_context = borrowed_egui;
     }

--- a/src/editor_window.rs
+++ b/src/editor_window.rs
@@ -14,7 +14,7 @@ pub(crate) fn yoleck_editor_window(
     } else {
         return;
     };
-    egui::Window::new("Level Editor").show(borrowed_egui.get_mut(), |ui| {
+    egui::Window::new("Level Editor").vscroll(true).show(borrowed_egui.get_mut(), |ui| {
         world.resource_scope(
             |world, mut yoleck_editor_sections: Mut<YoleckEditorSections>| {
                 for section in yoleck_editor_sections.0.iter_mut() {


### PR DESCRIPTION
I have an expandable list of all sub-entities that a spawner editor object creates. This potentially becomes very long (50+ lines in the common case), which makes the editor window expand to go off-screen. This makes things outside the screen unreachable.

My solution was to add a vertical scroll to the editor window. This has the downside that you have to manually resize the editor window to have more contents, instead of the current behaviour of making the editor window fit to the size of the contents, but it has the benefit of letting you access all contents of the editor window.

This is an opinionated change, and it's more important to me that the need of having long editor windows supported is fulfilled, and less important that it's solved in exactly this way, so feel free to solve it another way if you like.

And if this is not something you want to have in the library, I'll just keep using my modified version, so no pressure.