### PR TITLE
Prevent property panel clicks from clearing selection

### DIFF
--- a/src/vpeol.rs
+++ b/src/vpeol.rs
@@ -14,14 +14,14 @@ use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use bevy::render::render_resource::PrimitiveTopology;
 use bevy::window::{PrimaryWindow, WindowRef};
-use bevy_egui::EguiContexts;
+use bevy_egui::{EguiContexts, egui};
 
 use crate::entity_management::YoleckRawEntry;
 use crate::knobs::YoleckKnobMarker;
 use crate::prelude::{YoleckEditorState, YoleckUi};
 use crate::{
-    YoleckDirective, YoleckEditMarker, YoleckEditorEvent, YoleckEntityConstructionSpecs,
-    YoleckManaged, YoleckRunEditSystems, YoleckState,
+    YoleckDirective, YoleckEditMarker, YoleckEditorEvent, YoleckEditorViewportRect,
+    YoleckEntityConstructionSpecs, YoleckManaged, YoleckRunEditSystems, YoleckState,
 };
 
 pub mod prelude {
@@ -288,6 +288,7 @@ fn handle_camera_state(
     mut directives_writer: MessageWriter<YoleckDirective>,
     global_drag_plane: Res<VpeolDragPlane>,
     drag_plane_overrides_query: Query<&VpeolOverrideDragPlane>,
+    editor_viewport: Res<YoleckEditorViewportRect>,
 ) -> Result {
     enum MouseButtonOp {
         JustPressed,
@@ -334,6 +335,17 @@ fn handle_camera_state(
         let Some(cursor_in_screen_pos) = window.cursor_position() else {
             continue;
         };
+        if matches!(*window_ref, WindowRef::Primary)
+            && matches!(mouse_button_op, MouseButtonOp::JustPressed)
+            && editor_viewport.rect.is_some_and(|rect| {
+                !rect.contains(egui::Pos2::new(
+                    cursor_in_screen_pos.x,
+                    cursor_in_screen_pos.y,
+                ))
+            })
+        {
+            continue;
+        }
 
         match (&mouse_button_op, &camera_state.clicks_on_objects_state) {
             (MouseButtonOp::JustPressed, VpeolClicksOnObjectsState::Empty) => {

--- a/tests/vpeol_input.rs
+++ b/tests/vpeol_input.rs
@@ -1,0 +1,57 @@
+#![cfg(feature = "vpeol")]
+
+use bevy::{
+    camera::RenderTarget,
+    prelude::*,
+    state::app::StatesPlugin,
+    window::{PrimaryWindow, WindowRef},
+};
+use bevy_yoleck::{
+    YoleckDirective, YoleckEditMarker, YoleckEditorViewportRect,
+    bevy_egui::{EguiContext, EguiUserTextures, PrimaryEguiContext, egui},
+    prelude::YoleckPluginForEditor,
+    vpeol::{VpeolBasePlugin, VpeolCameraState, VpeolDragPlane},
+};
+
+#[test]
+fn clicking_outside_the_editor_viewport_does_not_change_selection() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, AssetPlugin::default(), StatesPlugin))
+        .add_plugins(YoleckPluginForEditor)
+        .init_resource::<ButtonInput<MouseButton>>()
+        .init_resource::<ButtonInput<KeyCode>>()
+        .init_resource::<EguiUserTextures>()
+        .insert_resource(VpeolDragPlane::XY)
+        .insert_resource(YoleckEditorViewportRect {
+            rect: Some(egui::Rect::from_min_max(
+                egui::pos2(300.0, 40.0),
+                egui::pos2(1000.0, 700.0),
+            )),
+        })
+        .add_plugins(VpeolBasePlugin);
+
+    let mut window = Window::default();
+    window.set_cursor_position(Some(Vec2::new(1100.0, 300.0)));
+    app.world_mut().spawn((window, PrimaryWindow));
+    app.world_mut()
+        .spawn((EguiContext::default(), PrimaryEguiContext));
+    app.world_mut().spawn((
+        RenderTarget::Window(WindowRef::Primary),
+        VpeolCameraState {
+            cursor_ray: Some(Ray3d::new(Vec3::ZERO, Dir3::Z)),
+            ..default()
+        },
+    ));
+    app.world_mut().spawn(YoleckEditMarker);
+    app.world_mut()
+        .resource_mut::<ButtonInput<MouseButton>>()
+        .press(MouseButton::Left);
+
+    app.update();
+
+    assert!(
+        app.world()
+            .resource::<Messages<YoleckDirective>>()
+            .is_empty()
+    );
+}


### PR DESCRIPTION
Closes #50.

## What changed

Vpeol now ignores new primary-window clicks outside `YoleckEditorViewportRect`. This prevents clicks in editor panels from being interpreted as empty viewport clicks while leaving viewport selection and dragging unchanged.

A regression test covers clicking outside the editor viewport while an entity is selected.

## Why

The Properties panel is built on an egui background layer, where `is_pointer_over_egui()` can return false. Vpeol would therefore process a Properties click and clear the current selection.

## Validation

- Manually tested in a Bevy 0.19 game using the local Yoleck checkout
- Confirmed Properties sliders and controls no longer clear selection
- `cargo test --all-features`
- Regression test fails without the fix and passes with it